### PR TITLE
Implement Stylus color palette stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,19 @@ Copy the `nord.less` file into your project and import it in your [LESSCSS](http
 ```
 Information about how the `@import` statement handles imports with different file extensions can be found in the [official LESSCSS documentation](http://lesscss.org/features/#import-directives-feature).
 
+### <img src="http://stylus-lang.com/favicon.ico" width=16 height=16 /> Stylus
+
+Copy the [`nord.styl`][nord-stylus] file into your project and import it in your [Stylus][stylus] files by either using `@require` or `@import`:
+
+```stylus
+@require "nord";
+```
+
+Information about how the `@require` and `@import` statement handles imports with different file extensions and directory structures can be found in the [official Stylus documentation][stylus-import].
+
 #### KSS
-Nord LESSCSS sources are documented using the [KSS](http://warpspire.com/kss) documentation syntax.  
+Nord LESSCSS- and Stylus sources are documented using the [KSS](http://warpspire.com/kss) documentation syntax.
+
 Information about the generation of a styleguide can be found in the [official KSS documentation](http://warpspire.com/kss/styleguides).
 
 ### <img src="https://cdn.rawgit.com/arcticicestudio/nord/develop/src/assets/icon-color-swatch.svg"/> Color Swatches
@@ -123,3 +134,6 @@ Please report issues/bugs, feature requests and suggestions for improvements to 
 <p align="center"><a href="http://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"/></a> <a href="https://creativecommons.org/licenses/by-sa/4.0"><img src="https://img.shields.io/badge/License-CC_BY--SA_4.0-blue.svg"/></a></p>
 
 [gulp]: http://gulpjs.com
+[nord-stylus]: https://github.com/arcticicestudio/nord/blob/develop/src/stylus/nord.styl
+[stylus]: http://stylus-lang.com
+[stylus-import]: http://stylus-lang.com/docs/import.html#stylus-import

--- a/src/stylus/nord.styl
+++ b/src/stylus/nord.styl
@@ -1,0 +1,206 @@
+//
+// ++++++++++++++++++++++++++++++++++++++++++++++++++++
+// title      Nord                                    +
+// project    nord                                    +
+// version    0.2.0                                   +
+// repository https://github.com/arcticicestudio/nord +
+// author     Arctic Ice Studio                       +
+// email      development@arcticicestudio.com         +
+// copyright  Copyright (C) 2017                      +
+// ++++++++++++++++++++++++++++++++++++++++++++++++++++
+//
+// [References]
+// Stylus
+//   (http://stylus-lang.com)
+////
+// / An arctic, north-bluish color palette.
+// / Created for the clean- and minimal flat design pattern to achieve a optimal focus and readability for code syntax
+// / highlighting and UI.
+// / It consists of a total of sixteen, carefully selected, dimmed pastel colors for a eye-comfortable, but yet colorful
+// / ambiance.
+//
+// / @author Arctic Ice Studio <development@arcticicestudio.com>
+// //
+/// Base component color of "Polar Night".
+//
+// / Used for texts, backgrounds, carets and structuring characters like curly- and square brackets.
+//
+// / @access public
+// / @example scss - SCSS
+// / /* For dark ambiance themes
+// / .background
+// /   background-color: $nord0
+// / /* For light ambiance themes
+// / .text
+// /   color: $nord0
+// / @group polarnight
+// / @since 0.1.0
+$nord0 = #2e3440
+/// Lighter shade color of the base component color.
+//
+// / Used as a lighter background color for UI elements like status bars.
+//
+// / @access public
+// / @group polarnight
+// / @see $nord0
+// / @since 0.1.0
+$nord1 = #3b4252
+/// Lighter shade color of the base component color.
+//
+// / Used as line highlighting in the editor.
+// / In the UI scope it may be used as selection- and hightlight color.
+//
+// / @access public
+// / @example scss - SCSS
+// / /* Code Syntax Highlighting scope
+// / .editor
+// /   &.line
+// /     background-color: $nord2
+// / /* UI scope
+// / button
+// /   &:selected
+// /     background-color: $nord2
+// / @group polarnight
+// / @see $nord0
+// / @since 0.1.0
+$nord2 = #434c5e
+/// Lighter shade color of the base component color.
+//
+// / Used for comments, invisibles, indent- and wrap guide marker.
+// / In the UI scope used as pseudoclass color for disabled elements.
+//
+// / @access public
+// / @example scss - SCSS
+// / /* Code Syntax Highlighting scope
+// / .editor
+// /   &.indent-guide,
+// /      &.wrap-guide
+// /     &.marker
+// /       color: $nord3
+// / .comment,
+// /    .invisible
+// /   color: $nord3
+// / /* UI scope
+// / button
+// /   &:disabled
+// /     background-color: $nord3
+// / @group polarnight
+// / @see $nord0
+// / @since 0.1.0
+$nord3 = #4c566a
+/// Base component color of "Snow Storm".
+//
+// / Main color for text, variables, constants and attributes.
+// / In the UI scope used as semi-light background depending on the theme shading design.
+//
+// / @access public
+// / @example scss - SCSS
+// / /* For light ambiance themes
+// / .background
+// /   background-color: $nord4
+// / /* For dark ambiance themes
+// / .text
+// /   color: $nord4
+// / @group snowstorm
+// / @since 0.1.0
+$nord4 = #d8dee9
+/// Lighter shade color of the base component color.
+//
+// / Used as a lighter background color for UI elements like status bars.
+// / Used as semi-light background depending on the theme shading design.
+//
+// / @access public
+// / @group snowstorm
+// / @see $nord4
+// / @since 0.1.0
+$nord5 = #e5e9f0
+/// Lighter shade color of the base component color.
+//
+// / Used for punctuations, carets and structuring characters like curly- and square brackets.
+// / In the UI scope used as background, selection- and hightlight color depending on the theme shading design.
+//
+// / @access public
+// / @group snowstorm
+// / @see $nord4
+// / @since 0.1.0
+$nord6 = #eceff4
+/// Bluish core color.
+//
+// / Used for classes, types and documentation tags.
+//
+// / @access public
+// / @group frost
+// / @since 0.1.0
+$nord7 = #8fbcbb
+/// Bluish core accent color.
+//
+// / Represents the accent color of the color palette.
+// / Main color for primary UI elements and methods/functions.
+//
+// / Can be used for
+// /   - Markup quotes
+// /   - Markup link URLs
+//
+// / @access public
+// / @group frost
+// / @since 0.1.0
+$nord8 = #88c0d0
+/// Bluish core color.
+//
+// / Used for language-specific syntactic/reserved support characters and keywords, operators, tags, units and
+// / punctuations like (semi)colons,commas and braces.
+//
+// / @access public
+// / @group frost
+// / @since 0.1.0
+$nord9 = #81a1c1
+/// Bluish core color.
+//
+// / Used for markup doctypes, import/include/require statements, pre-processor statements and at-rules (`@`).
+//
+// / @access public
+// / @group frost
+// / @since 0.1.0
+$nord10 = #5e81ac
+/// Colorful component color.
+//
+// / Used for errors, git/diff deletion and linter marker.
+//
+// / @access public
+// / @group aurora
+// / @since 0.1.0
+$nord11 = #bf616a
+/// Colorful component color.
+//
+// / Used for annotations.
+//
+// / @access public
+// / @group aurora
+// / @since 0.1.0
+$nord12 = #d08770
+/// Colorful component color.
+//
+// / Used for escape characters, regular expressions and markup entities.
+// / In the UI scope used for warnings and git/diff renamings.
+//
+// / @access public
+// / @group aurora
+// / @since 0.1.0
+$nord13 = #ebcb8b
+/// Colorful component color.
+//
+// / Main color for strings and attribute values.
+// / In the UI scope used for git/diff additions and success visualizations.
+//
+// / @access public
+// / @group aurora
+// / @since 0.1.0
+$nord14 = #a3be8c
+/// Colorful component color.
+//
+// / Used for numbers.
+//
+// / @access public
+// / @group aurora
+// / @since 0.1.0
+$nord15 = #b48ead

--- a/src/stylus/nord.styl
+++ b/src/stylus/nord.styl
@@ -1,206 +1,199 @@
+/*
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+title      Nord                                    +
+project    nord                                    +
+version    0.3.0                                   +
+repository https://github.com/arcticicestudio/nord +
+author     Arctic Ice Studio                       +
+email      development@arcticicestudio.com         +
+copyright  Copyright (C) 2017                      +
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+[References]
+Stylus
+  http://stylus-lang.com
+KSS
+  http://warpspire.com/kss
+  https://github.com/kss-node/kss-node
+*/
+
+// An arctic, north-bluish color palette.
+// Created for the clean- and minimal flat design pattern to achieve a optimal focus and readability for code syntax
+// highlighting and UI.
+// It consists of a total of sixteen, carefully selected, dimmed pastel colors for a eye-comfortable, but yet colorful
+// ambiance.
 //
-// ++++++++++++++++++++++++++++++++++++++++++++++++++++
-// title      Nord                                    +
-// project    nord                                    +
-// version    0.2.0                                   +
-// repository https://github.com/arcticicestudio/nord +
-// author     Arctic Ice Studio                       +
-// email      development@arcticicestudio.com         +
-// copyright  Copyright (C) 2017                      +
-// ++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Styleguide Nord
+
+// Base component color of "Polar Night".
 //
-// [References]
-// Stylus
-//   (http://stylus-lang.com)
-////
-// / An arctic, north-bluish color palette.
-// / Created for the clean- and minimal flat design pattern to achieve a optimal focus and readability for code syntax
-// / highlighting and UI.
-// / It consists of a total of sixteen, carefully selected, dimmed pastel colors for a eye-comfortable, but yet colorful
-// / ambiance.
+// Used for texts, backgrounds, carets and structuring characters like curly- and square brackets.
 //
-// / @author Arctic Ice Studio <development@arcticicestudio.com>
-// //
-/// Base component color of "Polar Night".
+// Markup:
+// <div style="background-color:#2E3440; width=60; height=60"></div>
 //
-// / Used for texts, backgrounds, carets and structuring characters like curly- and square brackets.
+// Styleguide Nord - Polar Night
+nord0 = #2E3440;
+
+// Lighter shade color of the base component color.
 //
-// / @access public
-// / @example scss - SCSS
-// / /* For dark ambiance themes
-// / .background
-// /   background-color: $nord0
-// / /* For light ambiance themes
-// / .text
-// /   color: $nord0
-// / @group polarnight
-// / @since 0.1.0
-$nord0 = #2e3440
-/// Lighter shade color of the base component color.
+// Used as a lighter background color for UI elements like status bars.
 //
-// / Used as a lighter background color for UI elements like status bars.
+// Markup:
+// <div style="background-color:#3B4252; width=60; height=60"></div>
 //
-// / @access public
-// / @group polarnight
-// / @see $nord0
-// / @since 0.1.0
-$nord1 = #3b4252
-/// Lighter shade color of the base component color.
+// Styleguide Nord - Polar Night
+nord1 = #3B4252;
+
+// Lighter shade color of the base component color.
 //
-// / Used as line highlighting in the editor.
-// / In the UI scope it may be used as selection- and hightlight color.
+// Used as line highlighting in the editor.  
+// In the UI scope it may be used as selection- and hightlight color.
 //
-// / @access public
-// / @example scss - SCSS
-// / /* Code Syntax Highlighting scope
-// / .editor
-// /   &.line
-// /     background-color: $nord2
-// / /* UI scope
-// / button
-// /   &:selected
-// /     background-color: $nord2
-// / @group polarnight
-// / @see $nord0
-// / @since 0.1.0
-$nord2 = #434c5e
-/// Lighter shade color of the base component color.
+// Markup:
+// <div style="background-color:#434C5E; width=60; height=60"></div>
 //
-// / Used for comments, invisibles, indent- and wrap guide marker.
-// / In the UI scope used as pseudoclass color for disabled elements.
+// Styleguide Nord - Polar Night
+nord2 = #434C5E;
+
+// Lighter shade color of the base component color.
 //
-// / @access public
-// / @example scss - SCSS
-// / /* Code Syntax Highlighting scope
-// / .editor
-// /   &.indent-guide,
-// /      &.wrap-guide
-// /     &.marker
-// /       color: $nord3
-// / .comment,
-// /    .invisible
-// /   color: $nord3
-// / /* UI scope
-// / button
-// /   &:disabled
-// /     background-color: $nord3
-// / @group polarnight
-// / @see $nord0
-// / @since 0.1.0
-$nord3 = #4c566a
-/// Base component color of "Snow Storm".
+// Used for comments, invisibles, indent- and wrap guide marker.  
+// In the UI scope used as pseudoclass color for disabled elements.
 //
-// / Main color for text, variables, constants and attributes.
-// / In the UI scope used as semi-light background depending on the theme shading design.
+// Markup:
+// <div style="background-color:#4C566A; width=60; height=60"></div>
 //
-// / @access public
-// / @example scss - SCSS
-// / /* For light ambiance themes
-// / .background
-// /   background-color: $nord4
-// / /* For dark ambiance themes
-// / .text
-// /   color: $nord4
-// / @group snowstorm
-// / @since 0.1.0
-$nord4 = #d8dee9
-/// Lighter shade color of the base component color.
+// Styleguide Nord - Polar Night
+nord3 = #4C566A;
+
+// Base component color of "Snow Storm".
 //
-// / Used as a lighter background color for UI elements like status bars.
-// / Used as semi-light background depending on the theme shading design.
+// Main color for text, variables, constants and attributes.
+// In the UI scope used as semi-light background depending on the theme shading design.
 //
-// / @access public
-// / @group snowstorm
-// / @see $nord4
-// / @since 0.1.0
-$nord5 = #e5e9f0
-/// Lighter shade color of the base component color.
+// Markup:
+// <div style="background-color:#D8DEE9; width=60; height=60"></div>
 //
-// / Used for punctuations, carets and structuring characters like curly- and square brackets.
-// / In the UI scope used as background, selection- and hightlight color depending on the theme shading design.
+// Styleguide Nord - Snow Storm
+nord4 = #D8DEE9;
+
+// Lighter shade color of the base component color.
 //
-// / @access public
-// / @group snowstorm
-// / @see $nord4
-// / @since 0.1.0
-$nord6 = #eceff4
-/// Bluish core color.
+// Used as a lighter background color for UI elements like status bars.  
+// Used as semi-light background depending on the theme shading design.
 //
-// / Used for classes, types and documentation tags.
+// Markup:
+// <div style="background-color:#E5E9F0; width=60; height=60"></div>
 //
-// / @access public
-// / @group frost
-// / @since 0.1.0
-$nord7 = #8fbcbb
-/// Bluish core accent color.
+// Styleguide Nord - Snow Storm
+nord5 = #E5E9F0;
+
+// Lighter shade color of the base component color.
 //
-// / Represents the accent color of the color palette.
-// / Main color for primary UI elements and methods/functions.
+// Used for punctuations, carets and structuring characters like curly- and square brackets.  
+// In the UI scope used as background, selection- and hightlight color depending on the theme shading design.
 //
-// / Can be used for
-// /   - Markup quotes
-// /   - Markup link URLs
+// Markup:
+// <div style="background-color:#ECEFF4; width=60; height=60"></div>
 //
-// / @access public
-// / @group frost
-// / @since 0.1.0
-$nord8 = #88c0d0
-/// Bluish core color.
+// Styleguide Nord - Snow Storm
+nord6 = #ECEFF4;
+
+// Bluish core color.
 //
-// / Used for language-specific syntactic/reserved support characters and keywords, operators, tags, units and
-// / punctuations like (semi)colons,commas and braces.
+// Used for classes, types and documentation tags.
 //
-// / @access public
-// / @group frost
-// / @since 0.1.0
-$nord9 = #81a1c1
-/// Bluish core color.
+// Markup:
+// <div style="background-color:#8FBCBB; width=60; height=60"></div>
 //
-// / Used for markup doctypes, import/include/require statements, pre-processor statements and at-rules (`@`).
+// Styleguide Nord - Frost
+nord7 = #8FBCBB;
+
+// Bluish core color.
 //
-// / @access public
-// / @group frost
-// / @since 0.1.0
-$nord10 = #5e81ac
-/// Colorful component color.
+// Represents the accent color of the color palette.  
+// Main color for primary UI elements and methods/functions.  
 //
-// / Used for errors, git/diff deletion and linter marker.
+// Can be used for
+//   - Markup quotes
+//   - Markup link URLs
 //
-// / @access public
-// / @group aurora
-// / @since 0.1.0
-$nord11 = #bf616a
-/// Colorful component color.
+// Markup:
+// <div style="background-color:#88C0D0; width=60; height=60"></div>
 //
-// / Used for annotations.
+// Styleguide Nord - Frost
+nord8 = #88C0D0;
+
+// Bluish core color.
 //
-// / @access public
-// / @group aurora
-// / @since 0.1.0
-$nord12 = #d08770
-/// Colorful component color.
+// Used for language-specific syntactic/reserved support characters and keywords, operators, tags, units and
+// punctuations like (semi)colons,commas and braces.
 //
-// / Used for escape characters, regular expressions and markup entities.
-// / In the UI scope used for warnings and git/diff renamings.
+// Markup:
+// <div style="background-color:#81A1C1; width=60; height=60"></div>
 //
-// / @access public
-// / @group aurora
-// / @since 0.1.0
-$nord13 = #ebcb8b
-/// Colorful component color.
+// Styleguide Nord - Frost
+nord9 = #81A1C1;
+
+// Bluish core color.
 //
-// / Main color for strings and attribute values.
-// / In the UI scope used for git/diff additions and success visualizations.
+// Used for markup doctypes, import/include/require statements, pre-processor statements and at-rules (`@`).
 //
-// / @access public
-// / @group aurora
-// / @since 0.1.0
-$nord14 = #a3be8c
-/// Colorful component color.
+// Markup:
+// <div style="background-color:#5E81AC; width=60; height=60"></div>
 //
-// / Used for numbers.
+// Styleguide Nord - Frost
+nord10 = #5E81AC;
+
+// Colorful component color.
 //
-// / @access public
-// / @group aurora
-// / @since 0.1.0
-$nord15 = #b48ead
+// Used for errors, git/diff deletion and linter marker.
+//
+// Markup:
+// <div style="background-color:#BF616A; width=60; height=60"></div>
+//
+// Styleguide Nord - Aurora
+nord11 = #BF616A;
+
+// Colorful component color.
+//
+// Used for annotations.
+//
+// Markup:
+// <div style="background-color:#D08770; width=60; height=60"></div>
+//
+// Styleguide Nord - Aurora
+nord12 = #D08770;
+
+// Colorful component color.
+//
+// Used for escape characters, regular expressions and markup entities.  
+// In the UI scope used for warnings and git/diff renamings.
+//
+// Markup:
+// <div style="background-color:#EBCB8B; width=60; height=60"></div>
+//
+// Styleguide Nord - Aurora
+nord13 = #EBCB8B;
+
+// Colorful component color.
+//
+// Main color for strings and attribute values.  
+// In the UI scope used for git/diff additions and success visualizations.
+//
+// Markup:
+// <div style="background-color:#A3BE8C; width=60; height=60"></div>
+//
+// Styleguide Nord - Aurora
+nord14 = #A3BE8C;
+
+// Colorful component color.
+//
+// Used for numbers.
+//
+// Markup:
+// <div style="background-color:#B48EAD; width=60; height=60"></div>
+//
+// Styleguide Nord - Aurora
+nord15 = #B48EAD;


### PR DESCRIPTION
Since Nord has LESS and SASS variants, I've ported the palette to a stylus stylesheet.
I've maintained the examples from the SASS file making the appropriate syntax changes to them.
Let me know if there's anything that needs changing.