### PR TITLE
Feature: PostCSS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ body {
 }
 ```
 
+When using [postcss-import](https://github.com/postcss/postcss-import) you can simply import the CSS file like any JavaScript module:
+
+```css
+@import "nord";
+```
+
 When using the [optimized Nord CSS module][ghio-docs-dev-building-optimized-css-module] the import statement must be adjusted to match the path of the distributed file:
 
 ```css

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ body {
 }
 ```
 
-When using [postcss-import](https://github.com/postcss/postcss-import) you can simply import the CSS file like any JavaScript module:
+When using [postcss-import][gh-postcss-import] you can simply import the CSS file like any JavaScript module:
 
 ```css
 @import "nord";
@@ -273,6 +273,7 @@ The guide also includes information about [minimal, complete, and verifiable exa
 [gh-repo-nord-xcode]: https://github.com/arcticicestudio/nord-xcode
 [gh-repo-nord-xfce-terminal]: https://github.com/arcticicestudio/nord-xfce-terminal
 [gh-repo-nord-xresources]: https://github.com/arcticicestudio/nord-xresources
+[gh-repo-postcss-import]: https://github.com/postcss/postcss-import
 [gh-tree-src]: https://github.com/arcticicestudio/nord/tree/develop/src
 [ghio-docs]: https://arcticicestudio.github.io/nord
 [ghio-docs-dev-building]: https://arcticicestudio.github.io/nord/development/building.html

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -48,6 +48,12 @@ body {
 }
 ```
 
+When using [postcss-import][gh-postcss-import] you can simply import the CSS file like any JavaScript module:
+
+```css
+@import "nord";
+```
+
 When using the [optimized Nord CSS module][dev-building-optimized-css-module] the import statement must be adjusted to match the path of the distributed file:
 
 ```css
@@ -57,6 +63,7 @@ When using the [optimized Nord CSS module][dev-building-optimized-css-module] th
 [color-swatches]: color-swatches.md
 [dev-building-optimized-css-module]: ../development/building.md#optimized-css-module
 
+[gh-repo-postcss-import]: https://github.com/postcss/postcss-import
 [less]: http://lesscss.org
 [mdn-css-vars]: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables
 [sass]: http://sass-lang.com

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "src/nord.scss",
     "src/nord.styl"
   ],
+  "style": "dist/nord.css",
   "scripts": {
     "clean": "del build dist",
     "dist": "npm run clean && npm run optimize:css && cpy build/nord.css dist",


### PR DESCRIPTION
Add style field to `package.json` and add section to readme.

> When importing a module, it will look for index.css or file referenced in `package.json` in the `style` or `main` fields. You can also provide manually multiples paths where to look at.
[postcss-import](https://github.com/postcss/postcss-import)