### PR TITLE
Fix nord-guake link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The guide also includes information about [minimal, complete, and verifiable exa
 [gh-repo-nord-emacs]: https://github.com/arcticicestudio/nord-emacs
 [gh-repo-nord-gedit]: https://github.com/arcticicestudio/nord-gedit
 [gh-repo-nord-gnome-terminal]: https://github.com/arcticicestudio/nord-gnome-terminal
-[gh-repo-nord-guake]: https://github.com/arcticicestudio/nord-gnome-terminal
+[gh-repo-nord-guake]: https://github.com/arcticicestudio/nord-guake
 [gh-repo-nord-highlightjs]: https://github.com/arcticicestudio/nord-highlightjs
 [gh-repo-nord-hyper]: https://github.com/arcticicestudio/nord-hyper
 [gh-repo-nord-iterm2]: https://github.com/arcticicestudio/nord-iterm2

--- a/docs/introduction/port-projects.md
+++ b/docs/introduction/port-projects.md
@@ -110,7 +110,7 @@ Nord provides official port projects to cover a wide range of applications, libr
 [gh-repo-nord-emacs]: https://github.com/arcticicestudio/nord-emacs
 [gh-repo-nord-gedit]: https://github.com/arcticicestudio/nord-gedit
 [gh-repo-nord-gnome-terminal]: https://github.com/arcticicestudio/nord-gnome-terminal
-[gh-repo-nord-guake]: https://github.com/arcticicestudio/nord-gnome-terminal
+[gh-repo-nord-guake]: https://github.com/arcticicestudio/nord-guake
 [gh-repo-nord-highlightjs]: https://github.com/arcticicestudio/nord-highlightjs
 [gh-repo-nord-hyper]: https://github.com/arcticicestudio/nord-hyper
 [gh-repo-nord-iterm2]: https://github.com/arcticicestudio/nord-iterm2


### PR DESCRIPTION
## Description

Fix nord-guake link in README

### Before

![Nord Guake][assets-port-banner-guake] links to https://github.com/arcticicestudio/nord-gnome-terminal

### After

![Nord Guake][assets-port-banner-guake] links to https://github.com/arcticicestudio/nord-guake

[assets-port-banner-guake]: https://cdn.rawgit.com/arcticicestudio/nord/develop/assets/nord-guake-banner.svg
