### PR TITLE
Change Gimp Palette To Be Interface Friendly

### DIFF
--- a/src/native/nord.gpl
+++ b/src/native/nord.gpl
@@ -1,5 +1,5 @@
 GIMP Palette
-Name: nord.gpl
+Name: Nord
 Columns: 1
 #
 46	52	64	nord0


### PR DESCRIPTION
Will display "Nord" on interfaces instead of "nord.gpl"